### PR TITLE
Allow interfaces as class in service definition.

### DIFF
--- a/ServiceDefinitionValidator.php
+++ b/ServiceDefinitionValidator.php
@@ -61,7 +61,7 @@ class ServiceDefinitionValidator implements ServiceDefinitionValidatorInterface
         if ($class) {
             $class = $this->containerBuilder->getParameterBag()->resolveValue($class);
 
-            if (!class_exists($class)) {
+            if (!class_exists($class) && !interface_exists($class)) {
                 throw new ClassNotFoundException($class);
             }
         } elseif ($this->shouldDefinitionHaveAClass($definition)) {

--- a/Tests/ServiceDefinitionValidatorTest.php
+++ b/Tests/ServiceDefinitionValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Matthias\SymfonyServiceDefinitionValidator\Tests;
 
+use Matthias\SymfonyServiceDefinitionValidator\Exception\ClassNotFoundException;
 use Matthias\SymfonyServiceDefinitionValidator\Exception\DefinitionHasNoClassException;
 use Matthias\SymfonyServiceDefinitionValidator\ServiceDefinitionValidator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -70,6 +71,22 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
             $validator->validate($definition);
         } catch (DefinitionHasNoClassException $e) {
             $this->fail('Abstract definitions should be allowed to have no class');
+        }
+    }
+
+    public function testDefinedClassCanBeInterface()
+    {
+        $validator = new ServiceDefinitionValidator(
+            new ContainerBuilder(),
+            $this->createMockDefinitionArgumentsValidator(),
+            $this->createMockMethodCallsValidator()
+        );
+
+        try {
+            // The choice for Serializable is arbitrary, any PHP interface would do
+            $validator->validate(new Definition('Serializable'));
+        } catch (ClassNotFoundException $e) {
+            $this->fail('Definition should be allowed to have an interface as class');
         }
     }
 


### PR DESCRIPTION
As mentioned in #2, we should allow interfaces as class in service definitions.
