### PR TITLE
update Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,40 @@
 language: php
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
+matrix:
+  include:
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=2.2.*
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=2.3.*
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=2.4.* EXPRESSION_LANGUAGE_VERSION=2.4.*
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=2.5.* EXPRESSION_LANGUAGE_VERSION=2.5.*
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=2.6.* EXPRESSION_LANGUAGE_VERSION=2.6.*
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=2.7.*@dev EXPRESSION_LANGUAGE_VERSION=2.7.*@dev
+    - php: 5.6
+      env: DEPENDENCY_INJECTION_VERSION=3.0.*@dev EXPRESSION_LANGUAGE_VERSION=3.0.*@dev
 
 env:
-  - DEPENDENCY_INJECTION_VERSION=2.2.* EXPRESSION_LANGUAGE_VERSION=2.4.*
-  - DEPENDENCY_INJECTION_VERSION=2.3.* EXPRESSION_LANGUAGE_VERSION=2.4.*
-  - DEPENDENCY_INJECTION_VERSION=2.4.* EXPRESSION_LANGUAGE_VERSION=2.4.*
-  - DEPENDENCY_INJECTION_VERSION=2.5.* EXPRESSION_LANGUAGE_VERSION=2.5.*
-  - DEPENDENCY_INJECTION_VERSION=2.6.* EXPRESSION_LANGUAGE_VERSION=2.6.*
-  - DEPENDENCY_INJECTION_VERSION=2.7.*@dev EXPRESSION_LANGUAGE_VERSION=2.7.*@dev
-  - DEPENDENCY_INJECTION_VERSION=3.0.*@dev EXPRESSION_LANGUAGE_VERSION=3.0.*@dev
+  global:
+    - DEPENDENCY_INJECTION_VERSION=""
+    - EXPRESSION_LANGUAGE_VERSION=""
 
-before_script:
-  - composer require symfony/dependency-injection:${DEPENDENCY_INJECTION_VERSION}
-  - composer require symfony/expression-language:${EXPRESSION_LANGUAGE_VERSION} --dev
+before_install:
+  - if [ "$DEPENDENCY_INJECTION_VERSION" != "" ]; then composer require --dev --no-update symfony/dependency-injection "$DEPENDENCY_INJECTION_VERSION"; fi
+  - if [ "$EXPRESSION_LANGUAGE_VERSION" != "" ]; then composer require --dev --no-update symfony/expression-language "$EXPRESSION_LANGUAGE_VERSION"; fi
+
+install:
+  - composer install --prefer-source
+
+script:
+  - vendor/bin/phpunit
 
 notifications:
   email: matthiasnoback@gmail.com

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "symfony/dependency-injection": "2.*"
     },
     "require-dev": {
+        "phpunit/phpunit": "~4.0",
         "symfony/config": "2.*",
-        "phpunit/phpunit": "3.7.*",
-        "symfony/expression-language": "2.4.*"
+        "symfony/expression-language": "~2.4"
     },
     "autoload": {
         "psr-4" : { "Matthias\\SymfonyServiceDefinitionValidator\\" : "" }


### PR DESCRIPTION
I thought that it is not really necessary to run tests against all available Symfony versions for every PHP version. Running them only with PHP 5.6 should be sufficient.

As far as I can see, there is also no reason to change the version constraints, but just improve the checks if the ExpressionLanguage support is available for the DependencyInjection component.

This needs to be rebased when #22 is merged.