### PR TITLE
add support for Parameter references

### DIFF
--- a/ArgumentValidator.php
+++ b/ArgumentValidator.php
@@ -8,6 +8,7 @@ use Matthias\SymfonyServiceDefinitionValidator\Exception\TypeHintMismatchExcepti
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ExpressionLanguage;
+use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\SyntaxError;
@@ -41,6 +42,10 @@ class ArgumentValidator implements ArgumentValidatorInterface
 
     private function validateArrayArgument($argument)
     {
+        if ($argument instanceof Parameter) {
+            $argument = $this->containerBuilder->getParameter($argument);
+        }
+
         if (!is_array($argument)) {
             throw new TypeHintMismatchException(sprintf(
                 'Argument of type "%s" should have been an array',

--- a/ResultingClassResolver.php
+++ b/ResultingClassResolver.php
@@ -4,6 +4,7 @@ namespace Matthias\SymfonyServiceDefinitionValidator;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Parameter;
 
 class ResultingClassResolver implements ResultingClassResolverInterface
 {
@@ -17,6 +18,10 @@ class ResultingClassResolver implements ResultingClassResolverInterface
     public function resolve(Definition $definition)
     {
         $class = $definition->getClass();
+
+        if ($class instanceof Parameter) {
+            $class = $this->containerBuilder->getParameter($class);
+        }
 
         return $this->resolvePlaceholders($class);
     }

--- a/Tests/ResultingClassResolverTest.php
+++ b/Tests/ResultingClassResolverTest.php
@@ -5,6 +5,7 @@ namespace Matthias\SymfonyServiceDefinitionValidator\Tests;
 use Matthias\SymfonyServiceDefinitionValidator\ResultingClassResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Parameter;
 
 class ResultingClassResolverTest extends \PHPUnit_Framework_TestCase
 {
@@ -21,13 +22,16 @@ class ResultingClassResolverTest extends \PHPUnit_Framework_TestCase
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setParameter('definition.class', 'stdClass');
+        $containerBuilder->setParameter('definition2.class', 'stdClass');
 
         $resolver = new ResultingClassResolver($containerBuilder);
 
         $definition = new Definition('%definition.class%');
-
         $resolvedClass = $resolver->resolve($definition);
+        $this->assertSame('stdClass', $resolvedClass);
 
+        $definition2 = new Definition(new Parameter('definition2.class'));
+        $resolvedClass = $resolver->resolve($definition2);
         $this->assertSame('stdClass', $resolvedClass);
     }
 }


### PR DESCRIPTION
Hi,

There was missing support for use of the `Parameter` class, i.e creating services like this:
```
$definition = new Definition(new Parameter('app.service.class'));
$definition->addArgument(new Parameter('app.array'))
```

I couldn't see a way to put the fixing logic in one place. Possibley a refactor would make it cleaner.

Also I've not been able to really write a test for the array parameter fix, as your `ArgumentValidatorTest` only tests failure cases, unless you want a non failure test for this particular edge case.

Thanks