### PR TITLE
be less strict for container type hints

### DIFF
--- a/ArgumentValidator.php
+++ b/ArgumentValidator.php
@@ -79,7 +79,7 @@ class ArgumentValidator implements ArgumentValidatorInterface
             $definition = $this->containerBuilder->findDefinition($referencedServiceId);
             // we don't have to check if the definition exists, since the ContainerBuilder itself does that already
         } else {
-            $definition = new Definition('Symfony\Component\DependencyInjection\Container');
+            $definition = new Definition('Symfony\Component\DependencyInjection\ContainerBuilder');
         }
 
         $this->validateDefinitionArgument($className, $definition);

--- a/Tests/ArgumentValidatorTest.php
+++ b/Tests/ArgumentValidatorTest.php
@@ -185,14 +185,38 @@ class ArgumentValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($parameter, $argument);
     }
 
-    public function testContainerReferenceArgumentDoesNotFail()
+    public function testContainerInterfaceReferenceArgumentDoesNotFail()
     {
         $class = 'Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ClassWithContainerInterfaceConstructorArgument';
 
         $parameter = new \ReflectionParameter(array($class, '__construct'), 'container');
         $argument = new Reference('service_container');
 
-        $validator = new ArgumentValidator(new ContainerBuilder(), $this->createMockResultingClassResolver());
+        $classResolver = $this->createMockResultingClassResolver();
+        $classResolver
+            ->expects($this->any())
+            ->method('resolve')
+            ->willReturn('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $validator = new ArgumentValidator(new ContainerBuilder(), $classResolver);
+
+        $validator->validate($parameter, $argument);
+    }
+
+    public function testContainerBuilderReferenceArgumentDoesNotFail()
+    {
+        $class = 'Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ClassWithContainerBuilderConstructorArgument';
+
+        $parameter = new \ReflectionParameter(array($class, '__construct'), 'container');
+        $argument = new Reference('service_container');
+
+        $classResolver = $this->createMockResultingClassResolver();
+        $classResolver
+            ->expects($this->any())
+            ->method('resolve')
+            ->willReturn('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $validator = new ArgumentValidator(new ContainerBuilder(), $classResolver);
 
         $validator->validate($parameter, $argument);
     }
@@ -208,8 +232,7 @@ class ArgumentValidatorTest extends \PHPUnit_Framework_TestCase
         $classResolver
             ->expects($this->any())
             ->method('resolve')
-            ->with(new Definition('Symfony\Component\DependencyInjection\Container'))
-            ->willReturn('Symfony\Component\DependencyInjection\Container');
+            ->willReturn('Symfony\Component\DependencyInjection\ContainerBuilder');
         $validator = new ArgumentValidator(new ContainerBuilder(), $classResolver);
 
         $this->setExpectedException('Matthias\SymfonyServiceDefinitionValidator\Exception\TypeHintMismatchException', 'ExpectedClass');

--- a/Tests/Fixtures/ClassWithContainerBuilderConstructorArgument.php
+++ b/Tests/Fixtures/ClassWithContainerBuilderConstructorArgument.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ClassWithContainerBuilderConstructorArgument
+{
+    public function __construct(ContainerBuilder $container)
+    {
+    }
+}


### PR DESCRIPTION
Loosen the check introduced in #37 to still allow use cases like https://github.com/matthiasnoback/symfony-service-definition-validator/pull/37#issuecomment-278639376.