### PR TITLE
Add assertion to kernel boot documentation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ class ContainerServiceDefinitionsTest extends WebTestCase
         $kernel = static::createKernel();
 
         $kernel->boot();
+    
+        $bootedProperty = (new \ReflectionObject($kernel))
+            ->getProperty('booted');
+        $bootedProperty->setAccessible(true);
+        self::assertTrue($bootedProperty->getValue($kernel));
     }
 }
 ```


### PR DESCRIPTION
When test is executed with phpunit 6.* a risky test arises due to a test without any assertion.

Looking to the Kernel code, the `boot` method changes the `booted` property to `true`, so we can assert this new value and remove the risky test.