### PR TITLE
Replace usage of `\ReflectionClass` with `is_a()` too fix issue with aliased classes

### DIFF
--- a/ArgumentValidator.php
+++ b/ArgumentValidator.php
@@ -31,7 +31,7 @@ class ArgumentValidator implements ArgumentValidatorInterface
     public function validate(\ReflectionParameter $parameter, $argument)
     {
         if ($parameter->isArray()) {
-            if ($parameter->allowsNull() && is_null($argument)) {
+            if (null === $argument && $parameter->allowsNull()) {
                 return;
             }
             $this->validateArrayArgument($argument);
@@ -141,9 +141,7 @@ class ArgumentValidator implements ArgumentValidatorInterface
             ));
         }
 
-        $resultingClass = get_class($result);
-
-        $this->validateClass($className, $resultingClass);
+        $this->validateClass($className, get_class($result));
     }
 
     private function validateClass($expectedClassName, $actualClassName)
@@ -152,8 +150,7 @@ class ArgumentValidator implements ArgumentValidatorInterface
             return;
         }
 
-        $reflectionClass = new \ReflectionClass($actualClassName);
-        if (!$reflectionClass->isSubclassOf($expectedClassName)) {
+        if (!is_a($actualClassName, $expectedClassName, true)) {
             throw new TypeHintMismatchException(sprintf(
                 'Argument for type-hint "%s" points to a service of class "%s"',
                 $expectedClassName,

--- a/Tests/ArgumentValidatorTest.php
+++ b/Tests/ArgumentValidatorTest.php
@@ -197,6 +197,27 @@ class ArgumentValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($parameter, $argument);
     }
 
+    public function testPassesWhenArgumentIsClassAlias()
+    {
+        $class = 'Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ClassWithTypeHintedAliasConstructorArgument';
+        $this->containerBuilder = new ContainerBuilder();
+        $definition = new Definition();
+        $this->containerBuilder->setDefinition('referenced_service', $definition);
+
+        $parameter = new \ReflectionParameter(array($class, '__construct'), 'expected');
+        $argument = new Reference('referenced_service');
+
+        $resultingClassResolver = $this->createMockResultingClassResolver();
+        $resultingClassResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($definition)
+            ->will($this->returnValue('\AliasedExpectedClass'));
+        $validator = new ArgumentValidator($this->containerBuilder, $resultingClassResolver);
+
+        $validator->validate($parameter, $argument);
+    }
+
     public function testFailsIfContainerReferenceArgumentIsInjectedForParameterWithIncompatibleTypeHint()
     {
         $class = 'Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ClassWithTypeHintedConstructorArgument';
@@ -219,7 +240,7 @@ class ArgumentValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function createMockResultingClassResolver()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\ResultingClassResolverInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\ResultingClassResolverInterface')->getMock();
     }
 
     private function skipTestIfExpressionsAreNotAvailable()

--- a/Tests/ArgumentsValidatorTest.php
+++ b/Tests/ArgumentsValidatorTest.php
@@ -7,10 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @test
-     */
-    public function ifRequiredArgumentIsMissingFails()
+    public function testIfRequiredArgumentIsMissingFails()
     {
         $validator = new ArgumentsValidator($this->createMockArgumentValidator());
         $class = 'Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ClassWithRequiredConstructorArguments';
@@ -23,6 +20,6 @@ class ArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function createMockArgumentValidator()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\ArgumentValidatorInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\ArgumentValidatorInterface')->getMock();
     }
 }

--- a/Tests/BatchServiceDefinitionValidatorTest.php
+++ b/Tests/BatchServiceDefinitionValidatorTest.php
@@ -33,8 +33,6 @@ class BatchServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $exception = $this->createException();
 
-
-
         $errorFactory
             ->expects($this->once())
             ->method('createValidationError')
@@ -60,12 +58,12 @@ class BatchServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function createMockErrorFactory()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\Error\ValidationErrorFactoryInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\Error\ValidationErrorFactoryInterface')->getMock();
     }
 
     private function createMockErrorList()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\Tests\Error\ValidationErrorListInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\Tests\Error\ValidationErrorListInterface')->getMock();
     }
 
     private function createMockDefinition()
@@ -78,7 +76,7 @@ class BatchServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function createMockValidator()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\ServiceDefinitionValidatorInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\ServiceDefinitionValidatorInterface')->getMock();
     }
 
     private function createException()
@@ -88,6 +86,6 @@ class BatchServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function createMockError()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\Error\ValidationErrorInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\Error\ValidationErrorInterface')->getMock();
     }
 }

--- a/Tests/ConstructorResolverTest.php
+++ b/Tests/ConstructorResolverTest.php
@@ -10,10 +10,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @test
-     */
-    public function ifConstructorDoesNotExistResolvedConstructorIsNull()
+    public function testIfConstructorDoesNotExistResolvedConstructorIsNull()
     {
         $containerBuilder = new ContainerBuilder();
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
@@ -24,10 +21,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($resolver->resolve($definition));
     }
 
-    /**
-     * @test
-     */
-    public function ifConstructorExistsResolvedConstructorIsConstructorMethod()
+    public function testIfConstructorExistsResolvedConstructorIsConstructorMethod()
     {
         $containerBuilder = new ContainerBuilder();
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
@@ -39,10 +33,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedConstructor, $resolver->resolve($definition));
     }
 
-    /**
-     * @test
-     */
-    public function ifConstructorIsNotPublicItFails()
+    public function testIfConstructorIsNotPublicItFails()
     {
         $containerBuilder = new ContainerBuilder();
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
@@ -51,15 +42,17 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
         $definition = new Definition('Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ClassWithNonPublicConstructor');
 
         $this->setExpectedException('Matthias\SymfonyServiceDefinitionValidator\Exception\NonPublicConstructorException');
-        $this->assertSame(null, $resolver->resolve($definition));
+        $this->assertNull($resolver->resolve($definition));
     }
 
     /**
-     * @test
      * @dataProvider getFactoryServiceAndFactoryMethodAreDefinedData
      */
-    public function ifFactoryServiceAndFactoryMethodAreDefinedResolvedConstructorIsFactoryMethod($factoryClass, Definition $definition, \ReflectionMethod $expectedConstructor)
-    {
+    public function testIfFactoryServiceAndFactoryMethodAreDefinedResolvedConstructorIsFactoryMethod(
+        $factoryClass,
+        Definition $definition,
+        \ReflectionMethod $expectedConstructor
+    ) {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->register('factory', $factoryClass);
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
@@ -95,11 +88,12 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test
      * @dataProvider getFactoryClassAndFactoryMethodAreDefinedData
      */
-    public function ifFactoryClassAndFactoryMethodAreDefinedResolvedConstructorIsFactoryMethod(Definition $definition, \ReflectionMethod $expectedConstructor)
-    {
+    public function testIfFactoryClassAndFactoryMethodAreDefinedResolvedConstructorIsFactoryMethod(
+        Definition $definition,
+        \ReflectionMethod $expectedConstructor
+    ) {
         $containerBuilder = new ContainerBuilder();
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
 
@@ -133,10 +127,9 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test
      * @dataProvider getFactoryClassDoesNotExistData
      */
-    public function ifFactoryClassDoesNotExistFails(Definition $definition)
+    public function testIfFactoryClassDoesNotExistFails(Definition $definition)
     {
         $containerBuilder = new ContainerBuilder();
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
@@ -171,10 +164,9 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test
      * @dataProvider getFactoryMethodIsNotStaticData
      */
-    public function ifFactoryMethodIsNotStaticItFails(Definition $definition)
+    public function testIfFactoryMethodIsNotStaticItFails(Definition $definition)
     {
         $containerBuilder = new ContainerBuilder();
         $resolver = new ConstructorResolver($containerBuilder, new ResultingClassResolver($containerBuilder));
@@ -208,10 +200,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
         return $data;
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryIsStringIsFactoryCallback()
+    public function testIfFactoryIsStringIsFactoryCallback()
     {
         if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'getFactory')) {
             $this->markTestSkipped('Support for callables as factories was introduced in Symfony 2.6');
@@ -226,10 +215,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new \ReflectionFunction('factoryCallback'), $resolver->resolve($definition));
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryFunctionDoesNotExistFails()
+    public function testIfFactoryFunctionDoesNotExistFails()
     {
         if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'getFactory')) {
             $this->markTestSkipped('Support for callables as factories was introduced in Symfony 2.6');

--- a/Tests/DefinitionArgumentsValidatorTest.php
+++ b/Tests/DefinitionArgumentsValidatorTest.php
@@ -7,10 +7,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 class DefinitionArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @test
-     */
-    public function ifDefinitionIsAbstractDefinitionSkipsValidation()
+    public function testIfDefinitionIsAbstractDefinitionSkipsValidation()
     {
         $definition = new Definition();
         $definition->setAbstract(true);
@@ -25,10 +22,7 @@ class DefinitionArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifDefinitionIsSyntheticSkipsValidation()
+    public function testIfDefinitionIsSyntheticSkipsValidation()
     {
         $definition = new Definition();
         $definition->setSynthetic(true);
@@ -43,10 +37,7 @@ class DefinitionArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifNoConstructorCouldBeFoundSkipsValidation()
+    public function testIfNoConstructorCouldBeFoundSkipsValidation()
     {
         $class = 'stdClass';
         $definition = new Definition($class);
@@ -68,10 +59,7 @@ class DefinitionArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifConstructorIsFoundValidatesUsingArgumentsValidator()
+    public function testIfConstructorIsFoundValidatesUsingArgumentsValidator()
     {
         $definition = new Definition();
         $arguments = array(0 => 'argument1', 1 => 'argument2');
@@ -96,10 +84,7 @@ class DefinitionArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function itConvertsAnAssociativeArrayOfArgumentsToANumericallyIndexedOrderedArray()
+    public function testItConvertsAnAssociativeArrayOfArgumentsToANumericallyIndexedOrderedArray()
     {
         $definition = new Definition();
         $arguments = array('named_argument1' => 'argument1', 'named_argument2' => 'argument2');
@@ -128,11 +113,11 @@ class DefinitionArgumentsValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function createMockConstructorResolver()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\ConstructorResolverInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\ConstructorResolverInterface')->getMock();
     }
 
     private function createMockArgumentsValidator()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\ArgumentsValidatorInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\ArgumentsValidatorInterface')->getMock();
     }
 }

--- a/Tests/Fixtures/ClassWithTypeHintedAliasConstructorArgument.php
+++ b/Tests/Fixtures/ClassWithTypeHintedAliasConstructorArgument.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures;
+
+class_alias('Matthias\SymfonyServiceDefinitionValidator\Tests\Fixtures\ExpectedClass', 'AliasedExpectedClass');
+
+class ClassWithTypeHintedAliasConstructorArgument
+{
+    public function __construct(\AliasedExpectedClass $expected)
+    {
+    }
+}

--- a/Tests/Functional/Fixtures/reported_problems.yml
+++ b/Tests/Functional/Fixtures/reported_problems.yml
@@ -2,9 +2,9 @@ services:
     pdo:
         class: PDO
         arguments:
-            dsn: "mysql:dbname=dbname;host=host"
-            user: "user"
-            password: "password"
+            - "mysql:dbname=dbname;host=host"
+            - "user"
+            - "password"
         calls:
             - [setAttribute, [3, 2]]
 

--- a/Tests/ServiceDefinitionValidatorTest.php
+++ b/Tests/ServiceDefinitionValidatorTest.php
@@ -153,10 +153,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryServiceIsSpecifiedWithoutFactoryMethodFails()
+    public function testIfFactoryServiceIsSpecifiedWithoutFactoryMethodFails()
     {
         $definition = new Definition('stdClass');
         if (method_exists($definition, 'setFactoryService')) {
@@ -176,10 +173,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryServiceDoesNotExistFails()
+    public function testIfFactoryServiceDoesNotExistFails()
     {
         $definition = new Definition('stdClass');
         if (method_exists($definition, 'setFactoryService')) {
@@ -201,10 +195,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryMethodDoesNotExistOnFactoryServiceFails()
+    public function testIfFactoryMethodDoesNotExistOnFactoryServiceFails()
     {
         $containerBuilder = new ContainerBuilder();
         $factoryDefinition = new Definition('stdClass');
@@ -228,10 +219,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function factoryCanBeProvidedByServiceDefinition()
+    public function testFactoryCanBeProvidedByServiceDefinition()
     {
         if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'getFactory')) {
             $this->markTestSkipped('Factory can be provided by service definition since Symfony 2.6');
@@ -251,10 +239,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryProvidedByServiceDefinitionClassDoesNotExistFails()
+    public function testIfFactoryProvidedByServiceDefinitionClassDoesNotExistFails()
     {
         if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'getFactory')) {
             $this->markTestSkipped('Factory can be provided by service definition since Symfony 2.6');
@@ -275,10 +260,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryProvidedByServiceDefinitionSpecifiedWithoutFactoryMethodFails()
+    public function testIfFactoryProvidedByServiceDefinitionSpecifiedWithoutFactoryMethodFails()
     {
         if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'getFactory')) {
             $this->markTestSkipped('Factory can be provided by service definition since Symfony 2.6');
@@ -299,10 +281,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validate($definition);
     }
 
-    /**
-     * @test
-     */
-    public function ifFactoryMethodDoesNotExistOnFactoryServiceProvidedByDefinitionFails()
+    public function testIfFactoryMethodDoesNotExistOnFactoryServiceProvidedByDefinitionFails()
     {
         if (!method_exists('Symfony\Component\DependencyInjection\Definition', 'getFactory')) {
             $this->markTestSkipped('Factory can be provided by service definition since Symfony 2.6');
@@ -326,7 +305,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function getNonExistingClassName()
     {
-        return md5(rand(1, 999));
+        return md5(mt_rand(1, 999));
     }
 
     /**
@@ -334,7 +313,7 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
      */
     private function createMockDefinitionArgumentsValidator()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\DefinitionArgumentsValidatorInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\DefinitionArgumentsValidatorInterface')->getMock();
     }
 
     /**
@@ -342,6 +321,6 @@ class ServiceDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
      */
     private function createMockMethodCallsValidator()
     {
-        return $this->getMock('Matthias\SymfonyServiceDefinitionValidator\MethodCallsValidatorInterface');
+        return $this->getMockBuilder('Matthias\SymfonyServiceDefinitionValidator\MethodCallsValidatorInterface')->getMock();
     }
 }


### PR DESCRIPTION
Fixes #43