### PR TITLE
Changes the composer command for requiring the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ By Matthias Noback
 
 Using Composer:
 
-    php composer.phar require matthiasnoback/symfony-service-definition-validator ~1
+    php composer.phar require matthiasnoback/symfony-service-definition-validator
 
 ## Problems the validator can spot
 


### PR DESCRIPTION
When following the instructions, the composer instructions:

```
php composer.phar require matthiasnoback/symfony-service-definition-validator ~1
```

Leads us to a failure since `~` is being interpreted as the shortcut for the `home` folder in mac and linux.

Ping @matthiasnoback 